### PR TITLE
Fix Puppetboard scenario on CentOS 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .yardoc
 modules/
 packaging/build
+*.deb
+*.rpm
 Puppetfile.lock
 configuration*.log
 .vagrant

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The "-i" switch to ensures that the environment is root's environment, which is 
 
 This module supports CentOS 7, Debian 9 and Ubuntu 16.04.
 
-The base scenarios have been tested on all platforms. Puppetboard has been tested on Ubuntu 16.04 and Debian 9. Foreman scenarios
-have been tested on CentOS 7.
+Puppetserver, PuppetDB and Puppetboard scenarios work across all supported platforms. Currently Foreman scenarios
+only work on CentOS 7.
 
 Ubuntu 18.04 can't be easily supported quite yet as Puppetlabs does not provide Puppet 5 packages for it. Additionally Ubuntu's official Vagrant box [does not have](https://github.com/cilium/cilium/issues/1918#issuecomment-344527888) the ifupdown package which Vagrant depends on.
 

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -69,6 +69,13 @@ class puppetmaster::puppetboard
   "${puppet_ssldir}/private_keys/${::fqdn}.pem"    => $puppetdb_key,
   "${puppet_ssldir}/certs/ca.pem"                  => $puppetdb_ca_cert, }
 
+  # Allow httpd to read Puppetboard's SSL keys
+  if $::osfamily == 'RedHat' {
+    $seltype = 'httpd_sys_content_t'
+  } else {
+    $seltype = undef
+  }
+
   $keys.each |$key| {
     exec { $key[1]:
       command => "cp -f ${key[0]} ${key[1]}",
@@ -80,6 +87,7 @@ class puppetmaster::puppetboard
     file { $key[1]:
       group   => 'puppetboard',
       mode    => '0640',
+      seltype => $seltype,
       require => Exec[$key[1]],
     }
   }

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -93,9 +93,12 @@ class puppetmaster::puppetboard
   }
 
   if "${facts['osfamily']}" == 'RedHat' {
+    include ::apache::mod::version
+
     class { 'apache::mod::wsgi':
       wsgi_socket_prefix => "/var/run/wsgi"
     }
+
   }
   else {
     class { '::apache::mod::wsgi': }

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -95,7 +95,7 @@ class puppetmaster::puppetboard
   if "${facts['osfamily']}" == 'RedHat' {
     include ::apache::mod::version
 
-    class { 'apache::mod::wsgi':
+    class { '::apache::mod::wsgi':
       wsgi_socket_prefix => "/var/run/wsgi"
     }
 


### PR DESCRIPTION
This makes puppetboard work on CentOS 7. The iptables/ip6tables rules are still preventing access to port 443, but that will be fixed separately.