### PR TITLE
Add basic packet filtering support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,6 +3,8 @@
 
 forge 'https://forgeapi.puppetlabs.com'
 
+mod 'puppetfinland-packetfilter'
+
 mod 'puppetfinland-kafo',
     :git => 'https://github.com/Puppet-Finland/puppet-kafo.git',
     :tag => '1.0.2'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,8 +28,6 @@ Vagrant.configure("2") do |config|
     box.vm.network "private_network", ip: "192.168.221.201"
     box.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
     box.vm.synced_folder ".", "/usr/share/puppetmaster-installer", type: "virtualbox"
-    box.vm.network "forwarded_port", guest: 443, host: 8443
-    box.vm.network "forwarded_port", guest: 80, host: 8080
     box.vm.provision "shell" do |s|
       s.path = "vagrant/prepare.sh"
       s.args = ["-b", "/usr/share/puppetmaster-installer"]
@@ -50,8 +48,6 @@ Vagrant.configure("2") do |config|
     # require this or the vboxsf mount will fail.
     box.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
     box.vm.synced_folder ".", "/usr/share/puppetmaster-installer", type: "virtualbox"
-    box.vm.network "forwarded_port", guest: 443, host: 8443
-    box.vm.network "forwarded_port", guest: 80, host: 8000
     box.vm.provision "shell" do |s|
       s.path = "vagrant/prepare.sh"
       s.args = ["-b", "/usr/share/puppetmaster-installer"]
@@ -69,8 +65,6 @@ Vagrant.configure("2") do |config|
     box.vm.network "private_network", ip: "192.168.221.203"
     box.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
     box.vm.synced_folder ".", "/usr/share/puppetmaster-installer", type: "virtualbox"
-    box.vm.network "forwarded_port", guest: 443, host: 8443
-    box.vm.network "forwarded_port", guest: 80, host: 8080
     box.vm.provision "shell" do |s|
       s.path = "vagrant/prepare.sh"
       s.args = ["-b", "/usr/share/puppetmaster-installer"]
@@ -88,8 +82,6 @@ Vagrant.configure("2") do |config|
     box.vm.network "private_network", ip: "192.168.221.204"
     box.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
     box.vm.synced_folder ".", "/usr/share/puppetmaster-installer", type: "virtualbox"
-    box.vm.network "forwarded_port", guest: 443, host: 8443
-    box.vm.network "forwarded_port", guest: 80, host: 8080
     box.vm.provision "shell" do |s|
       s.path = "vagrant/prepare.sh"
       s.args = ["-b", "/usr/share/puppetmaster-installer"]

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -1,18 +1,12 @@
 # Common configurations for all scenarios
 #
-# == Parameters:
-#
-# $reports_lifetime:: How long reports are stored. For example '14d'.
-#
-# $logs_lifetime:: How long logs are stored. For example '90d'.
-#
-# $hosts_entries:: Hash of additional host entries. 
 class puppetmaster::common
 (
+  Boolean       $manage_packetfilter,
   Array[String] $primary_names,
+  String        $timezone,
   String        $reports_lifetime = '14d',
   String        $logs_lifetime = '90d',
-  String        $timezone,
   Hash          $hosts_entries = {},
 )
 {
@@ -29,17 +23,9 @@ class puppetmaster::common
     timezone => $timezone,
   }
 
-
   class { '::hosts':
     primary_names => $primary_names,
     entries       => $hosts_entries,
-  }
-
-  @firewall { '8140 accept incoming agent traffic to puppetserver':
-    dport  => '8140',
-    proto  => 'tcp',
-    action => 'accept',
-    tag    => 'default',
   }
 
   file { '/var/files':
@@ -95,5 +81,16 @@ class puppetmaster::common
     recurse => true,
     rmdirs  => false,
     type    => ctime,
+  }
+
+  if $manage_packetfilter {
+    include ::packetfilter::endpoint
+
+    @firewall { '8140 accept incoming agent traffic to puppetserver':
+      dport  => '8140',
+      proto  => 'tcp',
+      action => 'accept',
+      tag    => 'default',
+    }
   }
 }

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -2,11 +2,8 @@
 #
 class puppetmaster::common
 (
-  Boolean       $manage_packetfilter,
   Array[String] $primary_names,
   String        $timezone,
-  String        $reports_lifetime = '14d',
-  String        $logs_lifetime = '90d',
   Hash          $hosts_entries = {},
 )
 {
@@ -26,71 +23,5 @@ class puppetmaster::common
   class { '::hosts':
     primary_names => $primary_names,
     entries       => $hosts_entries,
-  }
-
-  file { '/var/files':
-    ensure => 'directory',
-    mode   => '0660',
-    owner  => 'puppet',
-    group  => 'puppet',
-  }
-
-  file { '/etc/puppetlabs/puppet/fileserver.conf':
-    ensure => 'present'
-  }
-
-  ini_setting { 'files_path':
-    ensure            => present,
-    path              => '/etc/puppetlabs/puppet/fileserver.conf',
-    section           => 'files',
-    setting           => 'path',
-    value             => '/var/files',
-    key_val_separator => ' ',
-    require           => File['/etc/puppetlabs/puppet/fileserver.conf'],
-  }
-
-  ini_setting { 'files_allow':
-    ensure            => present,
-    path              => '/etc/puppetlabs/puppet/fileserver.conf',
-    section           => 'files',
-    setting           => 'allow',
-    value             => '*',
-    key_val_separator => ' ',
-    require           => File['/etc/puppetlabs/puppet/fileserver.conf'],
-  }
-
-  puppet_authorization::rule { 'files':
-    match_request_path => '^/puppet/v3/file_(content|metadata)s?/files/',
-    match_request_type => 'regex',
-    allow              => '*',
-    sort_order         => 400,
-    path               => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
-  }
-
-  tidy { '/opt/puppetlabs/server/data/puppetserver/reports':
-    age     => $reports_lifetime,
-    matches => "*.yaml",
-    recurse => true,
-    rmdirs  => false,
-    type    => ctime,
-  }
-
-  tidy { '/var/log/puppetlabs/puppetserver':
-    age     => $logs_lifetime,
-    matches => "puppetserver.*",
-    recurse => true,
-    rmdirs  => false,
-    type    => ctime,
-  }
-
-  if $manage_packetfilter {
-    include ::packetfilter::endpoint
-
-    @firewall { '8140 accept incoming agent traffic to puppetserver':
-      dport  => '8140',
-      proto  => 'tcp',
-      action => 'accept',
-      tag    => 'default',
-    }
   }
 }

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -4,6 +4,10 @@
 #
 # $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
 #
+# $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1.
+#
+# $puppetserver_allow_ipv6:: Allow connections to puppetserver from this IPv6 address or subnet. Defaults to '::1'.
+#
 # $server_reports:: Where to store reports. Defaults to 'store,puppetdb'.
 #
 # $autosign:: Set up autosign entries. Set to true to enable naive autosigning.
@@ -17,6 +21,8 @@
 class puppetmaster::puppetboard
 (
   Boolean                  $manage_packetfilter = true,
+  String                   $puppetserver_allow_ipv4 = '127.0.0.1',
+  String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
@@ -47,7 +53,6 @@ class puppetmaster::puppetboard
   $puppetdb_ca_cert                       = "${puppetboard_ssl_dir}/ca.pem"
 
   class { '::puppetmaster::common':
-    manage_packetfilter => $manage_packetfilter,
     primary_names       => $primary_names,
     timezone            => $timezone,
     before              => Class['::puppetboard'],
@@ -55,6 +60,8 @@ class puppetmaster::puppetboard
 
   class { '::puppetmaster::puppetdb':
     manage_packetfilter        => $manage_packetfilter,
+    puppetserver_allow_ipv4    => $puppetserver_allow_ipv4,
+    puppetserver_allow_ipv6    => $puppetserver_allow_ipv6,
     server_reports             => $server_reports,
     autosign                   => $autosign,
     autosign_entries           => $autosign_entries,

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -53,7 +53,6 @@ class puppetmaster::puppetboard
 
   class { '::puppetmaster::puppetdb':
     manage_packetfilter        => $manage_packetfilter,
-    timezone                   => $timezone,
     puppetserver_allow_ipv4    => $puppetserver_allow_ipv4,
     puppetserver_allow_ipv6    => $puppetserver_allow_ipv6,
     server_reports             => $server_reports,

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -33,7 +33,6 @@ class puppetmaster::puppetboard
 
   $puppetboard_puppetdb_host              = "${facts['fqdn']}"
   $puppetboard_puppetdb_port              = 8081
-  $primary_names                          = unique([ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ])
   $puppetboard_puppetdb_dashboard_address = "http://${facts['fqdn']}:8080/pdb/dashboard"
   $puppetboard_puppetdb_address           = "https://${facts['fqdn']}:8081/v2/commands"
   $puppetdb_server                        = $facts['fqdn']
@@ -52,14 +51,9 @@ class puppetmaster::puppetboard
   $puppetdb_key                           = "${puppetboard_ssl_dir}/${::fqdn}.key"
   $puppetdb_ca_cert                       = "${puppetboard_ssl_dir}/ca.pem"
 
-  class { '::puppetmaster::common':
-    primary_names       => $primary_names,
-    timezone            => $timezone,
-    before              => Class['::puppetboard'],
-  }
-
   class { '::puppetmaster::puppetdb':
     manage_packetfilter        => $manage_packetfilter,
+    timezone                   => $timezone,
     puppetserver_allow_ipv4    => $puppetserver_allow_ipv4,
     puppetserver_allow_ipv6    => $puppetserver_allow_ipv6,
     server_reports             => $server_reports,
@@ -67,6 +61,7 @@ class puppetmaster::puppetboard
     autosign_entries           => $autosign_entries,
     puppetdb_database_password => $puppetdb_database_password,
     timezone                   => $timezone,
+    before                     => Class['::puppetboard'],
   }
   
   file { [ $puppetboard_config_dir, $puppetboard_ssl_dir ]:

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -17,6 +17,7 @@
 # $puppetdb_database_password:: Password for the puppetdb database in postgresql
 #
 # $timezone:: The timezone the server wants to be located in. Example: 'Europe/Helsinki' or 'Etc/UTC'.
+#
 class puppetmaster::puppetdb
 (
   Boolean                  $manage_packetfilter = true,
@@ -29,9 +30,6 @@ class puppetmaster::puppetdb
   String                   $timezone
 )
 {
-
-  $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]
-
   class { '::puppetmaster::puppetserver':
     manage_packetfilter     => $manage_packetfilter,
     puppetserver_allow_ipv4 => $puppetserver_allow_ipv4,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -2,6 +2,8 @@
 #
 # == Parameters:
 #
+# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
+#
 # $server_reports:: Where to store reports. Defaults to 'store,puppetdb'.
 #
 # $autosign:: Set up autosign entries. Set to true to enable naive autosigning.
@@ -13,21 +15,23 @@
 # $timezone:: The timezone the server wants to be located in. Example: 'Europe/Helsinki' or 'Etc/UTC'.
 class puppetmaster::puppetdb
 (
+  Boolean                  $manage_packetfilter = true,
   String                   $server_reports = 'store,puppetdb',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
   String                   $puppetdb_database_password,
-  String                   $timezone 
+  String                   $timezone
 )
 {
 
   $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]
 
   class { '::puppetmaster::puppetserver':
-    server_reports   => $server_reports,
-    autosign         => $autosign,
-    autosign_entries => $autosign_entries,
-    timezone         => $timezone, 
+    manage_packetfilter => $manage_packetfilter,
+    server_reports      => $server_reports,
+    autosign            => $autosign,
+    autosign_entries    => $autosign_entries,
+    timezone            => $timezone, 
   }
 
   class { '::puppetdb':

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -4,6 +4,10 @@
 #
 # $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
 #
+# $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1'.
+#
+# $puppetserver_allow_ipv6:: Allow connections to puppetserver from this IPv6 address or subnet. Defaults to '::1'.
+#
 # $server_reports:: Where to store reports. Defaults to 'store,puppetdb'.
 #
 # $autosign:: Set up autosign entries. Set to true to enable naive autosigning.
@@ -16,6 +20,8 @@
 class puppetmaster::puppetdb
 (
   Boolean                  $manage_packetfilter = true,
+  String                   $puppetserver_allow_ipv4 = '127.0.0.1',
+  String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
@@ -27,11 +33,13 @@ class puppetmaster::puppetdb
   $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]
 
   class { '::puppetmaster::puppetserver':
-    manage_packetfilter => $manage_packetfilter,
-    server_reports      => $server_reports,
-    autosign            => $autosign,
-    autosign_entries    => $autosign_entries,
-    timezone            => $timezone, 
+    manage_packetfilter     => $manage_packetfilter,
+    puppetserver_allow_ipv4 => $puppetserver_allow_ipv4,
+    puppetserver_allow_ipv6 => $puppetserver_allow_ipv6,
+    server_reports          => $server_reports,
+    autosign                => $autosign,
+    autosign_entries        => $autosign_entries,
+    timezone                => $timezone, 
   }
 
   class { '::puppetdb':

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -28,7 +28,7 @@ class puppetmaster::puppetserver
   Hash                     $host_entries = {}
 )
 {
-  $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]  
+  $primary_names = unique([ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ])
 
   class { '::puppetmaster::common':
     primary_names       => $primary_names,

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -4,6 +4,10 @@
 #
 # $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
 #
+# $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1.
+#
+# $puppetserver_allow_ipv6:: Allow connections to puppetserver from this IPv6 address or subnet. Defaults to '::1'.
+#
 # $server_reports:: Where to store reports. Defaults to 'store'.
 #
 # $autosign:: Set up autosign entries. Set to true to enable naive autosigning.
@@ -14,24 +18,78 @@
 #
 class puppetmaster::puppetserver
 (
+  String                   $timezone,
   Boolean                  $manage_packetfilter = true,
+  String                   $puppetserver_allow_ipv4 = '127.0.0.1',
+  String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
-  String                   $timezone,
+  Hash                     $host_entries = {}
 )
 {
   $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]  
 
-  unless defined(Class['::puppetmaster::common']) {
-    
-    class { '::puppetmaster::common':
-      manage_packetfilter => $manage_packetfilter,
-      primary_names       => $primary_names,
-      timezone            => $timezone,
-   }
+  class { '::puppetmaster::common':
+    primary_names       => $primary_names,
+    timezone            => $timezone,
   }
-  
+
+  file { '/var/files':
+    ensure => 'directory',
+    mode   => '0660',
+    owner  => 'puppet',
+    group  => 'puppet',
+  }
+
+  file { '/etc/puppetlabs/puppet/fileserver.conf':
+    ensure => 'present'
+  }
+
+  ini_setting { 'files_path':
+    ensure            => present,
+    path              => '/etc/puppetlabs/puppet/fileserver.conf',
+    section           => 'files',
+    setting           => 'path',
+    value             => '/var/files',
+    key_val_separator => ' ',
+    require           => File['/etc/puppetlabs/puppet/fileserver.conf'],
+  }
+
+  ini_setting { 'files_allow':
+    ensure            => present,
+    path              => '/etc/puppetlabs/puppet/fileserver.conf',
+    section           => 'files',
+    setting           => 'allow',
+    value             => '*',
+    key_val_separator => ' ',
+    require           => File['/etc/puppetlabs/puppet/fileserver.conf'],
+  }
+
+  puppet_authorization::rule { 'files':
+    match_request_path => '^/puppet/v3/file_(content|metadata)s?/files/',
+    match_request_type => 'regex',
+    allow              => '*',
+    sort_order         => 400,
+    path               => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  }
+
+  tidy { '/opt/puppetlabs/server/data/puppetserver/reports':
+    age     => $reports_lifetime,
+    matches => "*.yaml",
+    recurse => true,
+    rmdirs  => false,
+    type    => ctime,
+  }
+
+  tidy { '/var/log/puppetlabs/puppetserver':
+    age     => $logs_lifetime,
+    matches => "puppetserver.*",
+    recurse => true,
+    rmdirs  => false,
+    type    => ctime,
+  }
+
   class { '::puppet':
     server                => true,
     show_diff             => false,
@@ -41,5 +99,28 @@ class puppetmaster::puppetserver
     server_external_nodes => '',
     server_reports        => $server_reports,
     require               => [ File['/etc/puppetlabs/puppet/fileserver.conf'], Puppet_authorization::Rule['files'] ],
+  }
+
+  if $manage_packetfilter {
+    include ::packetfilter::endpoint
+
+    $firewall_defaults = {
+      dport  => '8140',
+      proto  => 'tcp',
+      action => 'accept',
+      tag    => 'default',
+    }
+
+    @firewall { '8140 accept incoming agent ipv4 traffic to puppetserver':
+      provider => 'iptables',
+      source   => $puppetserver_allow_ipv4,
+      *        => $firewall_defaults,
+    }
+
+    @firewall { '8140 accept incoming agent ipv6 traffic to puppetserver':
+      provider => 'ip6tables',
+      source   => $puppetserver_allow_ipv6,
+      *        => $firewall_defaults,
+    }
   }
 }

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -2,6 +2,8 @@
 #
 # == Parameters:
 #
+# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
+#
 # $server_reports:: Where to store reports. Defaults to 'store'.
 #
 # $autosign:: Set up autosign entries. Set to true to enable naive autosigning.
@@ -9,23 +11,24 @@
 # $autosign_entries:: List of autosign entries. Requires that autosign is pointing to the path of autosign.conf.
 #
 # $timezone:: The timezone the server wants to be located in. Example: 'Europe/Helsinki' or 'Etc/UTC'.
+#
 class puppetmaster::puppetserver
 (
+  Boolean                  $manage_packetfilter = true,
   String                   $server_reports = 'store',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
   String                   $timezone,
 )
-
 {
-
   $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]  
 
   unless defined(Class['::puppetmaster::common']) {
     
     class { '::puppetmaster::common':
-      primary_names => $primary_names,
-      timezone      => $timezone, 
+      manage_packetfilter => $manage_packetfilter,
+      primary_names       => $primary_names,
+      timezone            => $timezone,
    }
   }
   


### PR DESCRIPTION
This is accomplished using the ::packetfilter::endpoint class from puppetfinland-packetfilter. This also includes major refactorings, in particular moving of many puppetserver configurations away from common.pp to puppetserver.pp. Parameters aimed at common.pp are passed down to it from the actual scenarios (puppetboard.pp, puppetdb.pp, puppetserver.pp). This may break some Foreman scenarios until they have been fixed again.