### PR TITLE
Fix ordering issue that prevented including the ::kafo class

### DIFF
--- a/vagrant/prepare.sh
+++ b/vagrant/prepare.sh
@@ -109,6 +109,14 @@ package { 'librarian-puppet':
 package { 'git':
   ensure => 'latest',
 }
+
+exec { 'Run librarian-puppet':
+  cwd       => "$BASEDIR",
+  logoutput => true,
+  command   => 'librarian-puppet install --verbose',
+  timeout   => 600,
+  path      => ['/bin','/usr/bin','/opt/puppetlabs/bin','/opt/puppetlabs/puppet/bin'],
+}
 EOF
 cat $FILE | /opt/puppetlabs/bin/puppet apply 
 rm $FILE
@@ -117,14 +125,6 @@ rm $FILE
 run_puppet_2() {
 FILE=$(mktemp)
 cat<<EOF>$FILE
-
-exec { 'Run librarian-puppet':
-  cwd     => "$BASEDIR",
-  command => 'librarian-puppet install',
-  timeout => 600,
-  path    => '/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:/usr/bin'
-}
-
 class { '::kafo':
   gem_provider => 'puppet_gem',
 }


### PR DESCRIPTION
The Exec that ran librarian-puppet was in the same dynamically generated Puppet
manifest as the call to ::kafo class. This meant that puppet apply did not have
access to the ::kafo class when it loaded the manifest and hence refused to
apply anything, including running the librarian-puppet Exec. Fix by moving the
Exec to first Puppet run cycle, so that when the second launches the modulepath
and ::kafo is ensured to be available.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>