### PR TITLE
Remove tidy resources

### DIFF
--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -85,22 +85,6 @@ class puppetmaster::puppetserver
     path               => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
   }
 
-  tidy { '/opt/puppetlabs/server/data/puppetserver/reports':
-    age     => $reports_lifetime,
-    matches => "*.yaml",
-    recurse => true,
-    rmdirs  => false,
-    type    => ctime,
-  }
-
-  tidy { '/var/log/puppetlabs/puppetserver':
-    age     => $logs_lifetime,
-    matches => "puppetserver.*",
-    recurse => true,
-    rmdirs  => false,
-    type    => ctime,
-  }
-
   class { '::puppet':
     server                                 => true,
     show_diff                              => $show_diff,


### PR DESCRIPTION
They are rather useless as the installer generally runs only when the
Puppetserver is installed, or possibly when it is updated. These resources
should rather go into a class included by the Puppetserver (e.g. a profile).
Also, the tidy resources used undefined variables $logs_lifetime and
$reports_lifetime, so they were probably using resource defaults for those.

Signed-off-by: Samuli Seppänen <samuli.seppanen@gmail.com>