### PR TITLE
Fix lots of warnings and a couple of real problems

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -13,7 +13,7 @@ class puppetmaster::common
     'Debian' => ['apt-transport-https'],
     'Ubuntu' => [],
   }
-  
+
   ensure_packages($packages)
 
   class { '::timezone':
@@ -27,7 +27,7 @@ class puppetmaster::common
     }
   }
   else {
-    
+
     class { '::hosts':
       primary_names => $primary_names,
       entries       => $valid_hosts_entries,

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -30,7 +30,7 @@ class puppetmaster::common
 
     class { '::hosts':
       primary_names => $primary_names,
-      entries       => $valid_hosts_entries,
+      entries       => $hosts_entries,
     }
   }
 }

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -1,3 +1,4 @@
+#
 class puppetmaster::control
 (
   String $control_repo_url,
@@ -5,18 +6,18 @@ class puppetmaster::control
   String $identity_key = '/etc/puppetlabs/r10k/ssh/control_private_key'
 )
 {
-  
+
   file { '/etc/puppetlabs/r10k/ssh':
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
   }
-  
+
   file { $identity_key:
     ensure  => 'present',
     mode    => '0400',
-    content  => $control_repo_deploy_key,
+    content => $control_repo_deploy_key,
     require => File['/etc/puppetlabs/r10k/ssh'],
   }
 
@@ -44,9 +45,9 @@ END
   }
 
   sshkey { 'Deploy key':
-    ensure => present,
-    target => '/root/.ssh/known_hosts',
-    key    => $control_repo_deploy_key,
+    ensure  => present,
+    target  => '/root/.ssh/known_hosts',
+    key     => $control_repo_deploy_key,
     require => File['/root/.ssh'],
   }
 
@@ -62,7 +63,7 @@ END
 }
 
 
-  
 
 
-  
+
+

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,3 +1,4 @@
+#
 define puppetmaster::database
 (
   String $dbname,
@@ -9,25 +10,25 @@ define puppetmaster::database
 
   $contrib_package_name = 'postgresql96-contrib'
   $connection_limit     = '300'
-  
+
   ::postgresql::server::role { $dbname:
     password_hash    => postgresql_password($username, $password),
     connection_limit => $connection_limit,
   }
-  
-  ::postgresql::server::database_grant { "Grant all to $username":
+
+  ::postgresql::server::database_grant { "Grant all to ${username}":
     privilege => 'ALL',
     db        => $dbname,
     role      => $username,
   }
-  
+
   ::postgresql::server::db { $dbname:
     user     => $username,
     password => postgresql_password($username, $password),
   }
-  
+
   if $extension_trgm {
-    
+
     ::postgresql::server::extension { 'Add trgm':
       database     => $dbname,
       package_name => $contrib_package_name,

--- a/manifests/databaseserver.pp
+++ b/manifests/databaseserver.pp
@@ -1,3 +1,4 @@
+#
 class puppetmaster::databaseserver
 (
   String $postgresql_version              = '9.6',
@@ -11,12 +12,12 @@ class puppetmaster::databaseserver
     manage_package_repo => $postgresql_manage_package_repo,
     version             => $postgresql_version,
   }
-  
+
   class { '::postgresql::server':
     listen_addresses => $postgresql_listen_address,
     require          => Class['::postgresql::globals']
-  }                                                       
-  
+  }
+
   ::postgresql::server::config_entry {'max_connections':
     value => $max_connections,
   }

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -86,7 +86,7 @@
 #
 class puppetmaster::foreman_proxy
 (
-  
+
   String $timezone,
   Array[String] $primary_names,
   String $foreman_proxy_foreman_base_url,
@@ -136,7 +136,7 @@ class puppetmaster::foreman_proxy
   }
 
   # $primary_names = [ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ]
-  $foreman_proxy_registered_name = "${facts['fqdn']}"
+  $foreman_proxy_registered_name = $facts['fqdn']
   $foreman_proxy_repo = '1.15'
   $foreman_proxy_version = '1.15.6'
   $foreman_proxy_bind_host = '0.0.0.0'
@@ -167,7 +167,7 @@ class puppetmaster::foreman_proxy
   $foreman_proxy_foreman_ssl_cert = "/etc/puppetlabs/puppet/ssl/certs/${foreman_proxy_registered_name}_foreman.pem"
   $foreman_proxy_foreman_ssl_key =  "/etc/puppetlabs/puppet/ssl/private_keys/${foreman_proxy_registered_name}_foreman.pem"
   $foreman_proxy_template_url = "http://${facts['networking']['interfaces'][$foreman_proxy_dhcp_interface]['ip']}:8000"
-  
+
   @firewall { '22 accept outgoing foreman-proxy remote ssh execution':
     chain  => 'OUTPUT',
     state  => ['NEW'],
@@ -248,10 +248,10 @@ class puppetmaster::foreman_proxy
   }
 
   unless defined(Class['::puppetmaster::common']) {
-    
+
     class { '::puppetmaster::common':
       primary_names => $primary_names,
-      timezone      => $timezone, 
+      timezone      => $timezone,
       hosts_entries => $hosts_entries,
       before        => Class['::foreman_proxy'],
     }
@@ -260,7 +260,7 @@ class puppetmaster::foreman_proxy
   class { '::epel':
     before => Class['::foreman_proxy'],
   }
-  
+
 class { '::puppet':
     server         => true,
     show_diff      => true,
@@ -274,10 +274,10 @@ class { '::puppet':
   package { 'libkadm5':
     ensure   => installed,
   }
-  
+
   package { 'rubygem-rkerberos':
-    provider => 'rpm',
     ensure   => installed,
+    provider => 'rpm',
     source   => 'https://kojipkgs.fedoraproject.org//packages/rubygem-rkerberos/0.1.3/5.el7/x86_64/rubygem-rkerberos-0.1.3-5.el7.x86_64.rpm',
     before   => Class['::foreman_proxy'],
     require  => Package['libkadm5'],

--- a/manifests/lcm.pp
+++ b/manifests/lcm.pp
@@ -263,7 +263,7 @@ class puppetmaster::lcm
     { $foreman_proxy3_ipaddress => $foreman_proxy3_hostnames },
     { $foreman_proxy4_ipaddress => $foreman_proxy4_hostnames })
 
-  unless ("${facts['osfamily']}" == 'RedHat' and "${facts['os']['release']['major']}" == '7') {
+  unless ($facts['osfamily'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
     fail("${facts['os']['name']} ${facts['os']['release']['full']} not supported yet")
   }
 
@@ -275,7 +275,7 @@ class puppetmaster::lcm
     $dynflow_in_core = true
   }
 
-  unless "${facts['osfamily']}" != 'RedHat' {
+  unless $facts['osfamily'] != 'RedHat' {
 
     class { '::selinux':
       mode => 'enforcing',

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -20,18 +20,18 @@
 #
 class puppetmaster::puppetboard
 (
+  String                   $timezone,
+  String                   $puppetdb_database_password,
   Boolean                  $manage_packetfilter = true,
   String                   $puppetserver_allow_ipv4 = '127.0.0.1',
   String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
-  String                   $timezone,
-  String                   $puppetdb_database_password,
 )
 {
 
-  $puppetboard_puppetdb_host              = "${facts['fqdn']}"
+  $puppetboard_puppetdb_host              = $facts['fqdn']
   $puppetboard_puppetdb_port              = 8081
   $puppetboard_puppetdb_dashboard_address = "http://${facts['fqdn']}:8080/pdb/dashboard"
   $puppetboard_puppetdb_address           = "https://${facts['fqdn']}:8081/v2/commands"
@@ -62,7 +62,7 @@ class puppetmaster::puppetboard
     timezone                   => $timezone,
     before                     => Class['::puppetboard'],
   }
-  
+
   file { [ $puppetboard_config_dir, $puppetboard_ssl_dir ]:
     ensure  => directory,
     owner   => 'root',
@@ -106,11 +106,11 @@ class puppetmaster::puppetboard
     default_mods      => false,
   }
 
-  if "${facts['osfamily']}" == 'RedHat' {
+  if $facts['osfamily'] == 'RedHat' {
     include ::apache::mod::version
 
     class { '::apache::mod::wsgi':
-      wsgi_socket_prefix => "/var/run/wsgi"
+      wsgi_socket_prefix => '/var/run/wsgi'
     }
 
   }
@@ -123,13 +123,13 @@ class puppetmaster::puppetboard
     puppetdb_host       => $puppetboard_puppetdb_host,
     puppetdb_port       => $puppetboard_puppetdb_port,
     manage_git          => $puppetboard_manage_git,
-    manage_virtualenv   => $puppetboard_manage_virtualenv, 
+    manage_virtualenv   => $puppetboard_manage_virtualenv,
     reports_count       => $puppetboard_reports_count,
     puppetdb_key        => $puppetdb_key,
     puppetdb_ssl_verify => $puppetdb_ca_cert,
     puppetdb_cert       => $puppetdb_cert,
   }
-  
+
   class { '::puppetboard::apache::conf': }
 
   if $manage_packetfilter {

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -51,7 +51,7 @@ class puppetmaster::puppetdb
     timezone                => $timezone,
     show_diff               => $show_diff,
     server_foreman          => $server_foreman,
-    hosts_entries           => $host_entries,
+    hosts_entries           => $hosts_entries,
     server_external_nodes   => $server_external_nodes,
   }
 

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -27,18 +27,18 @@
 # $server_external_nodes:: A string to an ENC executable. Default to empty string.
 class puppetmaster::puppetdb
 (
+  String                   $puppetdb_database_password,
+  String                   $timezone,
   Boolean                  $manage_packetfilter = true,
   String                   $puppetserver_allow_ipv4 = '127.0.0.1',
   String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
-  Optional[Array[String]]  $autosign_entries = undef,
-  String                   $puppetdb_database_password,
-  String                   $timezone,
   Boolean                  $show_diff = false,
   Boolean                  $server_foreman = false,
   Hash                     $hosts_entries = {},
   String                   $server_external_nodes = '',
+  Optional[Array[String]]  $autosign_entries = undef,
 )
 {
   class { '::puppetmaster::puppetserver':
@@ -48,7 +48,7 @@ class puppetmaster::puppetdb
     server_reports          => $server_reports,
     autosign                => $autosign,
     autosign_entries        => $autosign_entries,
-    timezone                => $timezone, 
+    timezone                => $timezone,
     show_diff               => $show_diff,
     server_foreman          => $server_foreman,
     hosts_entries           => $host_entries,
@@ -62,7 +62,7 @@ class puppetmaster::puppetdb
   }
 
   class { '::puppetdb::master::config':
-    puppetdb_server     => $facts['fqdn'],
-    restart_puppet      => true,
+    puppetdb_server => $facts['fqdn'],
+    restart_puppet  => true,
   }
 }

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -38,12 +38,12 @@ class puppetmaster::puppetserver
   String                   $server_external_nodes = '',
 )
 {
-  $primary_names = unique([ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ])
+  $primary_names = unique([ $facts['fqdn'], $facts['hostname'], 'puppet', "puppet.${facts['domain']}" ])
 
   class { '::puppetmaster::common':
-    primary_names       => $primary_names,
-    timezone            => $timezone,
-    hosts_entries       => $hosts_entries,
+    primary_names => $primary_names,
+    timezone      => $timezone,
+    hosts_entries => $hosts_entries,
   }
 
   file { '/var/files':

--- a/manifests/reboot.pp
+++ b/manifests/reboot.pp
@@ -10,8 +10,8 @@ class puppetmaster::reboot
 {
 
   $message = 'Puppetmaster-installer is rebooting this system'
-  
-  unless ("${facts['osfamily']}" == 'RedHat' and "${facts['os']['release']['major']}" == '7') {
+
+  unless ($facts['osfamily'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
     fail("${facts['os']['name']} ${facts['os']['release']['full']} not supported yet")
   }
 
@@ -19,18 +19,18 @@ class puppetmaster::reboot
     mode => 'enforcing',
     type => 'targeted',
   }
-  
+
   selinux::module { 'httpd_t':
     ensure    => 'present',
     source_te => '/usr/share/puppetmaster-installer/files/httpd_t.te',
     builder   => 'simple',
   }
-  
+
   exec { 'Relabel':
     command => '/bin/touch /.autorelabel',
     require => Selinux::Module['httpd_t'],
   }
-  
+
   reboot { 'Reboot after relabel':
     subscribe => Exec['Relabel'],
     apply     => $apply,


### PR DESCRIPTION
This PR fixes a ton of puppet-lint warnings (whitespace, indentation, double-quoted variables, location of "ensure" parameter). After these trivial fixes were done two actual problems were found (typoed variable names).

In addition this PR removes the tidy resources which were almost completely useless: one does not generally run the installer except when installing the puppetserver, so the tidy resources did not kick in when needed. They should go into a Puppet class (e.g. a profile) included by the puppetserver.