### PR TITLE
Ensure that puppetboard apache2 config fragment is loaded

### DIFF
--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -98,12 +98,20 @@ class puppetmaster::puppetboard
     }
   }
 
+  # Work around an issue in puppetlabs/apache
+  $apache_confd_dir = $::osfamily ? {
+    'Debian' => '/etc/apache2/conf-enabled',
+    'RedHat' => '/etc/httpd/conf.d',
+    default  => '/etc/httpd/conf.d',
+  }
+
   class { '::apache':
     purge_configs     => true,
     mpm_module        => 'prefork',
     default_vhost     => true,
     default_ssl_vhost => true,
     default_mods      => false,
+    confd_dir         => $apache_confd_dir,
   }
 
   if $facts['osfamily'] == 'RedHat' {


### PR DESCRIPTION
Puppetlabs-apache module overwrites /etc/apache2/apache2.conf so that only
fragments in /etc/apache2/conf.d are loaded. The problem is that all Ubuntu and
Debian releases made since Ubuntu 14.04 have used /etc/apache2/conf-enabled
instead. Moreover, the puppetboard module puts puppetboard.conf under
/etc/apache2/conf-enabled, so puppetboard won't work out of the box. With this
commit the correct $confd_dir is passed to the apache module.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>