### PR TITLE
Remove parameter hosts_entries from all classes and the answer file.

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -4,7 +4,6 @@ class puppetmaster::common
 (
   Array[String] $primary_names,
   String        $timezone,
-  Hash          $hosts_entries = {},
 )
 {
 
@@ -58,17 +57,8 @@ class puppetmaster::common
     timezone => $timezone,
   }
 
-  if empty($hosts_entries) {
-
-    class { '::hosts':
-      primary_names => $primary_names,
-    }
-  }
-  else {
-
-    class { '::hosts':
-      primary_names => $primary_names,
-      entries       => $hosts_entries,
-    }
+  class { '::hosts':
+    primary_names => $primary_names,
   }
 }
+

--- a/manifests/foreman_proxy.pp
+++ b/manifests/foreman_proxy.pp
@@ -162,7 +162,6 @@ class puppetmaster::foreman_proxy
   $foreman_proxy_puppetrun_provider = puppetssh
   $foreman_proxy_mcollective_user = root
   $foreman_proxy_puppetssh_sudo = true
-  $hosts_entries = { $foreman_ipaddress => $foreman_hostnames }
   $foreman_proxy_foreman_ssl_ca = '/etc/puppetlabs/puppet/ssl/certs/ca_foreman.pem'
   $foreman_proxy_foreman_ssl_cert = "/etc/puppetlabs/puppet/ssl/certs/${foreman_proxy_registered_name}_foreman.pem"
   $foreman_proxy_foreman_ssl_key =  "/etc/puppetlabs/puppet/ssl/private_keys/${foreman_proxy_registered_name}_foreman.pem"
@@ -252,7 +251,6 @@ class puppetmaster::foreman_proxy
     class { '::puppetmaster::common':
       primary_names => $primary_names,
       timezone      => $timezone,
-      hosts_entries => $hosts_entries,
       before        => Class['::foreman_proxy'],
     }
   }

--- a/manifests/lcm.pp
+++ b/manifests/lcm.pp
@@ -258,10 +258,6 @@ class puppetmaster::lcm
   $foreman_proxy_mcollective_user           = root
   $foreman_proxy_puppetssh_sudo             = true
   $foreman_server_external_nodes            = '/etc/puppetlabs/puppet/node.rb'
-  $hosts_entries                            = deep_merge(
-    { $foreman_proxy2_ipaddress => $foreman_proxy2_hostnames },
-    { $foreman_proxy3_ipaddress => $foreman_proxy3_hostnames },
-    { $foreman_proxy4_ipaddress => $foreman_proxy4_hostnames })
 
   unless ($facts['osfamily'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
     fail("${facts['os']['name']} ${facts['os']['release']['full']} not supported yet")
@@ -343,7 +339,6 @@ class puppetmaster::lcm
     server_foreman             => true,
     autosign                   => '/etc/puppetlabs/puppet/autosign.conf',
     server_reports             => 'store,foreman',
-    hosts_entries              => $hosts_entries,
     puppetdb_database_password => $puppetdb_database_password,
     timezone                   => $timezone,
     manage_packetfilter        => $manage_packetfilter,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -22,8 +22,6 @@
 #
 # $show_diff:: Show diff in the foreman user interface. Defaults to false.
 #
-# $hosts_entries:: A hash of host entries to put in /etc/hosts
-#
 # $server_external_nodes:: A string to an ENC executable. Default to empty string.
 class puppetmaster::puppetdb
 (
@@ -36,7 +34,6 @@ class puppetmaster::puppetdb
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Boolean                  $show_diff = false,
   Boolean                  $server_foreman = false,
-  Hash                     $hosts_entries = {},
   String                   $server_external_nodes = '',
   Optional[Array[String]]  $autosign_entries = undef,
 )
@@ -51,7 +48,6 @@ class puppetmaster::puppetdb
     timezone                => $timezone,
     show_diff               => $show_diff,
     server_foreman          => $server_foreman,
-    hosts_entries           => $hosts_entries,
     server_external_nodes   => $server_external_nodes,
   }
 

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -20,8 +20,6 @@
 #
 # $show_diff:: Show diff in the foreman user interface. Defaults to false.
 #
-# $hosts_entries:: A hash of host entries to put in /etc/hosts.
-#
 # $server_external_nodes:: The path to the ENC executable. Defaults to empty string.
 class puppetmaster::puppetserver
 (
@@ -32,7 +30,6 @@ class puppetmaster::puppetserver
   String                   $server_reports = 'store',
   Variant[Boolean, String] $autosign = '/etc/puppetlabs/puppet/autosign.conf',
   Optional[Array[String]]  $autosign_entries = undef,
-  Hash                     $hosts_entries = {},
   Boolean                  $show_diff = false,
   Boolean                  $server_foreman = false,
   String                   $server_external_nodes = '',
@@ -43,7 +40,6 @@ class puppetmaster::puppetserver
   class { '::puppetmaster::common':
     primary_names => $primary_names,
     timezone      => $timezone,
-    hosts_entries => $hosts_entries,
   }
 
   file { '/var/files':


### PR DESCRIPTION
This belongs to DNS as an A record anyway. Bring it back if/when we need it.
If we find it will be needed, work around the kafo limitation with
a proper ruby function.
Signed-off-by: Petri Lammi <petri.lammi@puppeteers.fi>