### PR TITLE
Lock explicitly defined modules to versions proven to work

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,32 +3,32 @@
 
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetfinland-packetfilter'
+mod 'puppetfinland-packetfilter', '2.0.3'
 
 mod 'puppetfinland-kafo',
     :git => 'https://github.com/Puppet-Finland/puppet-kafo.git',
     :tag => '1.0.2'
 
-mod 'puppetlabs-stdlib'
+mod 'puppetlabs-stdlib', '4.25.1'
 
 # Modules used in profiles
-mod 'puppetlabs-ntp', '>= 7.1.1'
-mod 'chrekh-hosts', '>= 2.3.0'
+mod 'puppetlabs-ntp', '7.1.1'
+mod 'chrekh-hosts', '2.3.1'
 mod 'saz-timezone', '5.0.2'
-mod 'puppetlabs-puppet_authorization', '>= 0.4.0'
-mod 'stahnma-epel', '>= 1.3.0'
+mod 'puppetlabs-puppet_authorization', '0.4.0'
+mod 'stahnma-epel', '1.3.0'
 mod 'ghoneycutt-dnsclient',
     :git => 'https://github.com/ghoneycutt/puppet-module-dnsclient.git',
     :ref => 'ee9c47b44d185db70ffc8f4fdefdcaaf7e923d12'
-mod 'saz-locales', '>= 2.5.1'
+mod 'saz-locales', '2.5.1'
 mod 'puppetlabs-puppetserver_gem',
     :git => 'https://github.com/Puppet-Finland/puppetlabs-puppetserver_gem.git',
     :ref => 'c03720943996eb1269ee914c2dc24686ca37848d'
 mod 'puppetlabs-vcsrepo', '2.3.0'
-mod 'puppetlabs-firewall', '>= 1.12.0'
+mod 'puppetlabs-firewall', '1.12.0'
 mod 'saz-memcached', '3.3.0'
-mod 'puppet-selinux', '>=1.5.2'
-mod 'puppetlabs-reboot', '>=2.0.0'
+mod 'puppet-selinux', '1.5.2'
+mod 'puppetlabs-reboot', '2.0.0'
 mod 'puppet-puppetboard',
     :git => 'https://github.com/voxpupuli/puppet-module-puppetboard.git',
     :ref => '7bff39638e1078d0b520e2222f068938fe8d9ed6'
@@ -47,15 +47,29 @@ mod 'puppetlabs-gcc',
     :ref => '9df39a91300be42ff583438996ed26b379131eca'
 
 # Foreman deps
-mod 'puppetlabs/mysql',         '>= 4.0.0'
-mod 'puppetlabs/postgresql',    '>= 4.8.0'
-mod 'puppetlabs/puppetdb'
-mod 'theforeman/dhcp',          :git => 'https://github.com/theforeman/puppet-dhcp'
-mod 'theforeman/dns',           :git => 'https://github.com/theforeman/puppet-dns'
-mod 'theforeman/git',           :git => 'https://github.com/theforeman/puppet-git'
-mod 'theforeman/tftp',          :git => 'https://github.com/theforeman/puppet-tftp'
+mod 'puppetlabs/mysql',         '5.3.0'
+mod 'puppetlabs/postgresql',    '5.4.0'
+mod 'puppetlabs/puppetdb', '6.0.2'
+mod 'theforeman/dhcp',
+    :git => 'https://github.com/theforeman/puppet-dhcp',
+    :commit => '28f86453915d507c02f00574f37d3a87b6867a9f'
+mod 'theforeman/dns',
+    :git => 'https://github.com/theforeman/puppet-dns',
+    :commit => 'ba640cda58d729d7931a74b6dd5d51d557701f68'
+mod 'theforeman/git',
+    :git => 'https://github.com/theforeman/puppet-git',
+    :commit => 'c7662b61cf31e45e13f28f7ce6a7a3a1b892cff6'
+mod 'theforeman/tftp',
+    :git => 'https://github.com/theforeman/puppet-tftp',
+    :commit => 'df5b665cc7574baeec612d79fc0057a0931fe067'
 
 # Foreman top-level modules
-mod 'theforeman/foreman',       :git => 'https://github.com/theforeman/puppet-foreman'
-mod 'theforeman/foreman_proxy', :git => 'https://github.com/theforeman/puppet-foreman_proxy'
-mod 'theforeman/puppet',        :git => 'https://github.com/theforeman/puppet-puppet'
+mod 'theforeman/foreman',
+    :git => 'https://github.com/theforeman/puppet-foreman',
+    :commit => '0b6d7232a4beaf042f019673dea4c7687f5e7a71'
+mod 'theforeman/foreman_proxy',
+    :git => 'https://github.com/theforeman/puppet-foreman_proxy',
+    :commit => 'ca69feb9ce9356bc80cd0a08abe542667481a3ad'
+mod 'theforeman/puppet',
+    :git => 'https://github.com/theforeman/puppet-puppet',
+    :commit => '73f7fe6cb344b1f00ff15e8779097e55bb0bf274'


### PR DESCRIPTION
This helps prevent breakage from module updates. Modules fetched as dependencies
are not locked to any particular version, but on the other hand their versions
are controlled by each module's metadata.json already.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>