### PR TITLE
Improve comments about the $confd_dir workaround

### DIFF
--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -98,7 +98,13 @@ class puppetmaster::puppetboard
     }
   }
 
-  # Work around an issue in puppetlabs/apache
+  # From Debian 8 onwards (and on recent Ubuntu versions) use conf-enabled 
+  # instead of conf.d dir. puppetlabs-apache module does not follow this 
+  # convention, and config files are not read from the correct place.
+  #
+  # https://tickets.puppetlabs.com/browse/MODULES-5990
+  # https://tickets.puppetlabs.com/browse/MODULES-3116
+  #
   $apache_confd_dir = $::osfamily ? {
     'Debian' => '/etc/apache2/conf-enabled',
     'RedHat' => '/etc/httpd/conf.d',


### PR DESCRIPTION
I misread the diff in [PR](https://github.com/Puppet-Finland/puppet-puppetmaster/pull/18) by @msvilp and reimplemented the same thing in [my own PR](https://github.com/Puppet-Finland/puppet-puppetmaster/pull/43). However, the comments in the @msvilp version were much better, so they're added by this separate PR.