### PR TITLE
Do not manage packetfilter rules by default

### DIFF
--- a/manifests/lcm.pp
+++ b/manifests/lcm.pp
@@ -145,7 +145,7 @@
 #
 # $foreman_proxy4_ipaddress:: IP address of additional smart proxy 3. Example: '1.2.3.6'
 #
-# $manage_packetfilter:: Manage the packet filter. Defaults to true.
+# $manage_packetfilter:: Manage the packet filter. Defaults to false.
 class puppetmaster::lcm
 (
   String $foreman_db_password,

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -2,7 +2,7 @@
 #
 # == Parameters:
 #
-# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
+# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to false.
 #
 # $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1.
 #
@@ -22,7 +22,7 @@ class puppetmaster::puppetboard
 (
   String                   $puppetdb_database_password,
   String                   $timezone = 'Etc/UTC',
-  Boolean                  $manage_packetfilter = true,
+  Boolean                  $manage_packetfilter = false,
   String                   $puppetserver_allow_ipv4 = '127.0.0.1',
   String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -2,7 +2,7 @@
 #
 # == Parameters:
 #
-# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
+# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to false.
 #
 # $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1'.
 #
@@ -27,7 +27,7 @@ class puppetmaster::puppetdb
 (
   String                   $puppetdb_database_password,
   String                   $timezone = 'Etc/UTC',
-  Boolean                  $manage_packetfilter = true,
+  Boolean                  $manage_packetfilter = false,
   String                   $puppetserver_allow_ipv4 = '127.0.0.1',
   String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store,puppetdb',

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -2,7 +2,7 @@
 #
 # == Parameters:
 #
-# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to true.
+# $manage_packetfilter:: Manage IPv4 and IPv6 rules. Defaults to false.
 #
 # $puppetserver_allow_ipv4:: Allow connections to puppetserver from this IPv4 address or subnet. Example: '10.0.0.0/8'. Defaults to '127.0.0.1.
 #
@@ -24,7 +24,7 @@
 class puppetmaster::puppetserver
 (
   String                   $timezone = 'Etc/UTC',
-  Boolean                  $manage_packetfilter = true,
+  Boolean                  $manage_packetfilter = false,
   String                   $puppetserver_allow_ipv4 = '127.0.0.1',
   String                   $puppetserver_allow_ipv6 = '::1',
   String                   $server_reports = 'store',


### PR DESCRIPTION
This prevents users from locking themselves out from the puppetmaster if they
forgot to set the IP ranges in the installer correctly.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>