### PR TITLE
Remove untested operating systems from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,24 +15,6 @@
       ]
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9"


### PR DESCRIPTION
While this module should work fine on various RHEL clones, only CentOS
7 has been really tested.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>