### PR TITLE
Remove untested operating systems from metadata.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ keys/
 /.idea/
 /.vagrant/
 /coverage/
-/bin/
 /doc/
 /Gemfile.local
 /Gemfile.lock

--- a/hooks/post/80_post.rb
+++ b/hooks/post/80_post.rb
@@ -10,6 +10,7 @@ if [0, 2].include? @kafo.exit_code
       end
     end
   rescue NoMethodError
+    nil
   end
   say "\n" + 'Please ensure that your firewall is not blocking access to the configured Puppet services'
 else

--- a/hooks/pre_commit/20_rand_passwords.rb
+++ b/hooks/pre_commit/20_rand_passwords.rb
@@ -10,12 +10,13 @@ def randomize_parameter(mod, param)
 end
 
 # Iterate over all scenarios/modules where PuppetDB password may be missing
-%w[puppetmaster_puppetdb puppetmaster_puppetboard puppetmaster_lcm].each do |mod|
+['puppetmaster_puppetdb', 'puppetmaster_puppetboard', 'puppetmaster_lcm'].each do |mod|
   begin
     randomize_parameter mod, 'puppetdb_database_password' if module_enabled? mod
   rescue NoMethodError
     # We get here every time this hook gets called, because only one of the
     # modules/scenarios will be active at a time.
+    nil
   end
 end
 
@@ -25,4 +26,5 @@ end
 begin
   randomize_parameter 'puppetmaster_puppetboard', 'puppetboard_password' if module_enabled? 'puppetmaster_puppetboard'
 rescue NoMethodError
+  nil
 end

--- a/manifests/lcm.pp
+++ b/manifests/lcm.pp
@@ -225,7 +225,7 @@ class puppetmaster::lcm
   $foreman_manage_memcached                 = true
   $foreman_memcached_max_memory             = '8%'
   $foreman_url                              = "https://${facts['fqdn']}"
-  $primary_names                            = unique([ "${facts['fqdn']}", "${facts['hostname']}", 'puppet', "puppet.${facts['domain']}" ])
+  $primary_names                            = unique([ $facts['fqdn'], $facts['hostname'], 'puppet', "puppet.${facts['domain']}" ])
   $foreman_serveraliases                    = $primary_names
   $foreman_puppetdb_dashboard_address       = "http://${facts['fqdn']}:8080/pdb/dashboard"
   $foreman_puppetdb_address                 = "https://${facts['fqdn']}:8081/v2/commands"

--- a/metadata.json
+++ b/metadata.json
@@ -15,24 +15,6 @@
       ]
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9"

--- a/vagrant/modules.pp
+++ b/vagrant/modules.pp
@@ -1,7 +1,7 @@
 notify { 'Running librarian-puppet': }
 
 exec { 'Run librarian-puppet':
-  cwd       => "${::basedir}",
+  cwd       => $::basedir,
   logoutput => true,
   command   => 'librarian-puppet install --verbose',
   timeout   => 600,


### PR DESCRIPTION
While this module should work fine on various RHEL clones, only CentOS
7 has been really tested.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.fi>