### PR TITLE
Lock Kafo version and install it directly without puppet-kafo

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -27,9 +27,6 @@ mod 'theforeman/git',
     :git => 'https://github.com/theforeman/puppet-git',
     :commit => 'c7662b61cf31e45e13f28f7ce6a7a3a1b892cff6'
 mod 'chrekh-hosts', '2.3.1'
-mod 'puppetfinland-kafo',
-    :git => 'https://github.com/Puppet-Finland/puppet-kafo.git',
-    :tag => '1.0.2'
 mod 'saz-locales', '2.5.1'
 mod 'puppet-make', '2.1.0'
 mod 'saz-memcached', '3.3.0'

--- a/vagrant/kafo.pp
+++ b/vagrant/kafo.pp
@@ -1,6 +1,24 @@
-notify { 'Installing Kafo': }
+notify { 'Installing Kafo and its dependencies': }
 
-class { '::kafo':
-  gem_provider => 'puppet_gem',
+package { 'rubygems':
+  ensure => 'present',
 }
 
+# We need to use a stable version of Highline module or kafo installers
+# won't work
+package { 'highline':
+  ensure   => '1.7.10',
+  provider => 'puppet_gem',
+}
+
+package { 'kafo':
+  ensure   => '2.1.0',
+  provider => 'puppet_gem',
+}
+
+$gems = [ 'rdoc', 'yard', 'puppet-strings', 'librarian-puppet' ]
+
+package { $gems:
+  ensure   => 'present',
+  provider => 'puppet_gem',
+}


### PR DESCRIPTION
The puppet-kafo module is not used outside of this installer and is quite
simplistic. Therefore move its code into kafo.pp into this installer.

URL: https://github.com/Puppet-Finland/puppet-puppetmaster/issues/87
Signed-off-by: Samuli Seppänen <samuli.seppanen@gmail.com>