### PR TITLE
Add support for Bitbucket plus auto-create $repo_host when possible

### DIFF
--- a/manifests/common/r10k.pp
+++ b/manifests/common/r10k.pp
@@ -3,9 +3,9 @@
 class puppetmaster::common::r10k
 (
   Optional[String] $provider,
+  Optional[String] $repo_host,
   String           $repo_url,
-  String           $key_path,
-  String           $repo_host,
+  String           $key_path
 )
 {
 
@@ -18,8 +18,9 @@ class puppetmaster::common::r10k
 
   case $provider {
     'gitlab': {
+      $l_repo_host = 'gitlab.com'
 
-      sshkey { 'gitlab.com':
+      sshkey { $l_repo_host:
         ensure  => present,
         type    => 'ecdsa-sha2-nistp256',
         target  => '/root/.ssh/known_hosts',
@@ -27,8 +28,23 @@ class puppetmaster::common::r10k
         require => File['/root/.ssh'],
       }
     }
+    'bitbucket': {
+      $l_repo_host = 'bitbucket.org'
+      sshkey { $l_repo_host:
+        ensure  => present,
+        type    => 'ssh-rsa',
+        target  => '/root/.ssh/known_hosts',
+        key     => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==',
+        require => File['/root/.ssh'],
+      }
+    }
     default: {
-      notify { "provider ${provider} is not yet supported. Place the of key of provider ${provider} in /root/.ssh/known_hosts": }
+      if $repo_host {
+        $l_repo_host = $repo_host
+        notify { "provider ${provider} is not yet supported. Ensure that ${provider} has an entry in /root/.ssh/known_hosts": }
+      } else {
+        fail('ERROR: you need to define the $repo_host parameter when using a custom provider!')
+      }
     }
   }
 

--- a/manifests/puppetboard.pp
+++ b/manifests/puppetboard.pp
@@ -30,13 +30,13 @@
 #
 # $server_external_nodes:: The path to the ENC executable. Defaults to empty string.
 #
-# $provider:: Your git repository provider. Provider 'gitlab' (gitlab.com) is fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
+# $provider:: Your git repository provider. Providers 'gitlab' (gitlab.com) and 'bitbucket' are fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
 # 
 # $repo_url:: The url to your control repository. Example: 'git@gitlab.com:mycompany/control-repo.git'
 #
 # $key_path:: The private key to use for accessing $repo_url. defaults to '/etc/puppetlabs/r10k/ssh/r10k_key'
 # 
-# $repo_host:: The fully qualified name of the $provider host. Example gitlab.com
+# $repo_host:: The fully qualified name of the $provider host. For example 'gitlab.com' or 'bitbucket.org'.
 class puppetmaster::puppetboard
 (
   String                   $puppetdb_database_password,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -28,13 +28,13 @@
 #
 # $show_diff:: Used internally in Foreman scenarios. Do not change the default (false) unless you know what you are doing.
 #
-# $provider:: Your git repository provider. Provider 'gitlab' (gitlab.com) is fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
+# $provider:: Your git repository provider. Providers 'gitlab' (gitlab.com) and 'bitbucket' are fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
 # 
 # $repo_url:: The url to your control repository. Example: 'git@gitlab.com:mycompany/control-repo.git'
 #
 # $key_path:: The private key to use for accessing $repo_url. defaults to '/etc/puppetlabs/r10k/ssh/r10k_key'
 # 
-# $repo_host:: The fully qualified name of the $provider host. Example gitlab.com
+# $repo_host:: The fully qualified name of the $provider host. For example 'gitlab.com' or 'bitbucket.org'.
 class puppetmaster::puppetdb
 (
   String                   $puppetdb_database_password,

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -28,13 +28,13 @@
 #
 # $show_diff:: Used internally in Foreman scenarios. Do not change the default (false) unless you know what you are doing.
 #
-# $provider:: Your git repository provider. Provider 'gitlab' (gitlab.com) is fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
+# $provider:: Your git repository provider. Providers 'gitlab' (gitlab.com) and 'bitbucket' are fully supported, but this parameter can be any string: you just need to add the public SSH key of the Git server to /root/.ssh/known_hosts manually.
 # 
 # $repo_url:: The url to your control repository. Example: 'git@gitlab.com:mycompany/control-repo.git'
 #
 # $key_path:: The private key to use for accessing $repo_url. defaults to '/etc/puppetlabs/r10k/ssh/r10k_key'
 # 
-# $repo_host:: The fully qualified name of the $provider host. Example gitlab.com
+# $repo_host:: The fully qualified name of the $provider host. For example 'gitlab.com' or 'bitbucket.org'.
 #
 class puppetmaster::puppetserver
 (

--- a/templates/ssh-config.erb
+++ b/templates/ssh-config.erb
@@ -1,4 +1,4 @@
-Host <%= @repo_host %>
+Host <%= @l_repo_host %>
 StrictHostKeyChecking no
 PubkeyAuthentication yes
 IdentityFile <%= @key_path %>


### PR DESCRIPTION
In case of 'gitlab' and 'bitbucket' (control repo) providers we know the
hostname of the Git server. So there is no need to make the user feed it
manually. However, when a custom provider is used the hostname needs to be
defined, so enforce that.

Signed-off-by: Samuli Seppänen <samuli.seppanen@gmail.com>