### PR TITLE
Automatically deploy eyaml and r10k keys

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -38,6 +38,8 @@ class puppetmaster::common
     *      => $eyaml_file_defaults,
   }
 
+  # For simplicity always create the eyaml keys, even if they get overwritten
+  # by user-defined keys in the next step.
   exec { 'create-eyaml-keys':
     user    => 'puppet',
     cwd     => $eyaml_dir,
@@ -47,10 +49,23 @@ class puppetmaster::common
     require => [ Package['hiera-eyaml'], File[$eyaml_dir] ],
   }
 
-  file { ["${eyaml_dir}/private_key.pkcs7.pem","${eyaml_dir}/public_key.pkcs7.pem"]:
-    mode    => '0600',
-    require => Exec['create-eyaml-keys'],
-    *       => $eyaml_file_defaults,
+  # If user has added eyaml keys into the installer directory copy them over.
+  # Even if keys are not there, ensure that their permissions are correct
+  ['private_key.pkcs7.pem','public_key.pkcs7.pem'].each |$eyaml_key| {
+    $installer_dir = '/usr/share/puppetmaster-installer'
+
+    exec { "copy-eyaml-key-${eyaml_key}":
+      cwd     => $installer_dir,
+      command => "test -r ${eyaml_key} && cp -v ${eyaml_key} ${eyaml_dir}/",
+      path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+      require => Exec['create-eyaml-keys'],
+    }
+
+    file { "${eyaml_dir}/${eyaml_key}":
+      mode    => '0600',
+      require => Exec["copy-eyaml-${eyaml_key}"],
+      *       => $eyaml_file_defaults,
+    }
   }
 
   class { '::timezone':

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -63,7 +63,7 @@ class puppetmaster::common
 
     file { "${eyaml_dir}/${eyaml_key}":
       mode    => '0600',
-      require => Exec["copy-eyaml-${eyaml_key}"],
+      require => Exec["copy-eyaml-key-${eyaml_key}"],
       *       => $eyaml_file_defaults,
     }
   }

--- a/manifests/common/r10k.pp
+++ b/manifests/common/r10k.pp
@@ -58,11 +58,25 @@ class puppetmaster::common::r10k
     },
   }
 
-  file { '/etc/puppetlabs/r10k/ssh':
+  $r10k_key_dir = '/etc/puppetlabs/r10k/ssh'
+
+  file { $r10k_key_dir:
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
+  }
+
+  # If user has added an r10k key into the installer directory copy it to the
+  # correct place. Even if keys are not there, ensure that their permissions
+  # are correct.
+  $installer_dir = '/usr/share/puppetmaster-installer'
+
+  exec { 'copy-r10k-key':
+    cwd     => $installer_dir,
+    command => "test -r r10k_key && cp -v r10k_key ${r10k_key_dir}/ && chown root:root ${r10k_key_dir}/r10k_key && chmod 600 ${r10k_key_dir}/r10k_key",
+    path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+    require => File[$r10k_key_dir],
   }
 
   file { '/root/.ssh/config':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetfinland-puppetmaster",
-  "version": "1.6.1",
+  "version": "1.7.2",
   "author": "Puppet-Finland team",
   "summary": "A simple wrapper class for setting up puppetmasters",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
We had support for automatically deploying eyaml and/or r10k placed in the installer directory. However, this functionality was limited to Vagrant and Virtualbox. Make this more generic, letting installer handle the copying of keys, if present. This allows fully automated Puppetmaster setup in production environment with pre-existing eyaml and r10k keys. 